### PR TITLE
refactor: remove required fields from StubOutput in API specification

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -484,9 +484,6 @@ components:
           x-go-type-skip-optional-pointer: true
     StubOutput:
       type: object
-      required:
-        - data
-        - error
       properties:
         data:
           type: object
@@ -519,5 +516,6 @@ components:
           x-go-type-import:
             name: time
             path: time
+          x-go-type-skip-optional-pointer: true
           description: Delay before sending the response
           example: "1s"


### PR DESCRIPTION
- Eliminated 'data' and 'error' from the required properties of the StubOutput object.
- Added 'x-go-type-skip-optional-pointer' for improved Go type handling.