### PR TITLE
refactor: remove x-go-type-skip-optional-pointer for delay parameter …

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -513,6 +513,5 @@ components:
         delay:
           type: string
           x-go-type: time.Duration
-          x-go-type-skip-optional-pointer: false
           description: Delay before sending the response
           example: "1s"


### PR DESCRIPTION
…in API specification

- Eliminated 'x-go-type-skip-optional-pointer' from the 'delay' parameter definition.
- This change simplifies the API specification and aligns with the intended Go type handling.